### PR TITLE
[feat] 라우팅 용 페이지 추가 및 라우터 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "export PORT=3000/posts && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,19 @@
+import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom';
+import { Posts, PostDetail, NotFound } from './pages';
 import GlobalStyled from './styles/global';
 
 function App() {
   return (
     <>
       <GlobalStyled />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Navigate to="/posts" replace />} />
+          <Route path="/posts" element={<Posts />} />
+          <Route path="/posts/:id" element={<PostDetail />} />
+          <Route path="/*" element={<NotFound />} />
+        </Routes>
+      </BrowserRouter>
     </>
   );
 }

--- a/src/pages/comments/Comments.jsx
+++ b/src/pages/comments/Comments.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Comments = () => {
+  return <div>{'코멘트 용 입니다'}</div>;
+};
+
+export default Comments;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,0 +1,4 @@
+export { default as Posts } from './posts/Posts';
+export { default as PostDetail } from './postDetail/PostDetail';
+export { default as Comments } from './comments/Comments';
+export { default as NotFound } from './notFound/NotFound';

--- a/src/pages/notFound/NotFound.jsx
+++ b/src/pages/notFound/NotFound.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const NotFound = () => {
+  return <div>{'찾지 못한다'}</div>;
+};
+
+export default NotFound;

--- a/src/pages/postDetail/PostDetail.jsx
+++ b/src/pages/postDetail/PostDetail.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PostDetail = () => {
+  return <div>{'상세 게시물 페이지'}</div>;
+};
+
+export default PostDetail;

--- a/src/pages/posts/Posts.jsx
+++ b/src/pages/posts/Posts.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Posts = () => {
+  return <div>{'게시물 리스트 페이지'}</div>;
+};
+
+export default Posts;


### PR DESCRIPTION
1. 라우팅 용 페이지(posts, postDetail, notFound, comments) 추가
2. /posts 메인 페이지 역활로 변경(react-router-dom ->  Navigate 컴포넌트 사용)